### PR TITLE
remove unicode character U+FEFF (zero-width space)

### DIFF
--- a/download_data/files_deepsea/deepsea_filelist.csv
+++ b/download_data/files_deepsea/deepsea_filelist.csv
@@ -1,4 +1,4 @@
-﻿http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeAwgDnaseUniform/wgEncodeAwgDnaseDuke8988tUniPk.narrowPeak.gz
+http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeAwgDnaseUniform/wgEncodeAwgDnaseDuke8988tUniPk.narrowPeak.gz
 http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeAwgDnaseUniform/wgEncodeAwgDnaseDukeAosmcUniPk.narrowPeak.gz
 http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeAwgDnaseUniform/wgEncodeAwgDnaseDukeChorionUniPk.narrowPeak.gz
 http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeAwgDnaseUniform/wgEncodeAwgDnaseDukeCllUniPk.narrowPeak.gz


### PR DESCRIPTION
This character was causing problems. Not sure how it got there.

The list of URLs can be downloaded using `wget` directly:

  ```
  wget -i deepsea_filelist.csv
  ```

The files will be downloaded in the current directory and named with whatever the URL ends with.

`-i` is short for `--input-file`